### PR TITLE
feat: Clean up Makefile by removing unused targets and commands

### DIFF
--- a/makefile
+++ b/makefile
@@ -273,8 +273,6 @@ help:
 # Default target
 .DEFAULT_GOAL := help
 
-interaction script:
-	forge script script/interaction-scripts/AMMScript.s.sol:AMMScript --rpc-url $BASE_SEPOLIA_RPC_URL --private-key $PRIVATE_KEY --broadcast -vvvv
 clear:
 	clear
 

--- a/makefile
+++ b/makefile
@@ -272,9 +272,7 @@ help:
 
 # Default target
 .DEFAULT_GOAL := help
-# ==============================================================================
-deploy all:
-	forge script script/DeployAll.s.sol:DeployAll --rpc-url $(BASE_SEPLOIA_RPC_URL) --private-key $(PRIVATE_KEY) --verify --verifier blockscout --verifier-url https://base-sepolia.blockscout.com/api/ --broadcast -vvvv
+
 interaction script:
 	forge script script/interaction-scripts/AMMScript.s.sol:AMMScript --rpc-url $BASE_SEPOLIA_RPC_URL --private-key $PRIVATE_KEY --broadcast -vvvv
 clear:

--- a/makefile
+++ b/makefile
@@ -272,5 +272,3 @@ help:
 
 # Default target
 .DEFAULT_GOAL := help
-
-forge script script/DeployAll.s.sol:DeployAll --rpc-url $BASE_SEPOLIA_RPC_URL --private-key $PRIVATE_KEY --verify --verifier blockscout --broadcast --verifier-url BASE_SEPOLIA_VERIFIER_URL

--- a/makefile
+++ b/makefile
@@ -273,9 +273,4 @@ help:
 # Default target
 .DEFAULT_GOAL := help
 
-clear:
-	clear
-
-
-
 forge script script/DeployAll.s.sol:DeployAll --rpc-url $BASE_SEPOLIA_RPC_URL --private-key $PRIVATE_KEY --verify --verifier blockscout --broadcast --verifier-url BASE_SEPOLIA_VERIFIER_URL


### PR DESCRIPTION
# PR Description
## Summary
This PR simplifies the project Makefile by removing unused or redundant targets and commented-out commands.

## Changes
- Removed **deploy all** target  
- Removed **interaction script** target  
- Removed **clear** target  
- Removed commented-out `forge script` command  

## Motivation
These targets and commands are no longer needed and clutter the Makefile.  
Cleaning them up improves **readability**, **maintainability**, and ensures only relevant automation scripts remain.
