### PR TITLE
feat(amm): add `userLiquidity` mapping and `pools` array with Natspec documentation

### DIFF
--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -85,4 +85,6 @@ contract Test_AMMContract is Ownable {
     /// @dev Tracks how much liquidity each user has provided to each market pool
     /// @dev Simplified tracking compared to NFT-based positions in the main contract
     mapping(address => mapping(bytes32 => uint256)) public userLiquidity;
+
+    PoolData[] public pools;
 }

--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -80,4 +80,7 @@ contract Test_AMMContract is Ownable {
     /// @dev Bidirectional mapping: both (tokenA, tokenB) and (tokenB, tokenA) point to same pool
     /// @dev In this simplified version, all pools are managed by this contract so address is always address(this)
     mapping(address => mapping(address => address)) public tokenPairToPoolAddress;
+
+        mapping(address => mapping(bytes32 => uint256)) public userLiquidity;
+
 }

--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -86,5 +86,7 @@ contract Test_AMMContract is Ownable {
     /// @dev Simplified tracking compared to NFT-based positions in the main contract
     mapping(address => mapping(bytes32 => uint256)) public userLiquidity;
 
+    /// @notice Array storing all created pools for enumeration and analytics
+    /// @dev Provides a way to iterate through all pools managed by this contract
     PoolData[] public pools;
 }

--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -81,6 +81,8 @@ contract Test_AMMContract is Ownable {
     /// @dev In this simplified version, all pools are managed by this contract so address is always address(this)
     mapping(address => mapping(address => address)) public tokenPairToPoolAddress;
 
-        mapping(address => mapping(bytes32 => uint256)) public userLiquidity;
-
+    /// @notice Maps user address and market ID to their liquidity amount
+    /// @dev Tracks how much liquidity each user has provided to each market pool
+    /// @dev Simplified tracking compared to NFT-based positions in the main contract
+    mapping(address => mapping(bytes32 => uint256)) public userLiquidity;
 }


### PR DESCRIPTION
# Description
This PR extends the `Test_AMMContract` by introducing liquidity tracking per user and an enumerable list of pools. These additions improve transparency, allow for easier analytics, and set the foundation for more advanced AMM functionality.

## Changes
- **New `userLiquidity` mapping**
  - Tracks the amount of liquidity each user has provided to specific markets.
  - Keyed by `(user address, market ID)` to allow precise liquidity accounting.
  - Simplifies tracking compared to NFT-based liquidity positions in the main AMM contract.

- **New `pools` array**
  - Stores all created pools in an array for iteration and analytics.
  - Provides a straightforward way to enumerate and query pools managed by the contract.
  - Improves observability for dApps, dashboards, and off-chain services.

- **Added Natspec comments**
  - Documented both new variables (`userLiquidity` and `pools`) with clear `@notice` and `@dev` descriptions.
  - Improved developer experience and contract readability.

## Motivation
- Enable developers and integrators to query liquidity contributions per user without relying on external tracking.
- Provide an enumerable structure (`pools` array) for easier indexing, monitoring, and analytics across the protocol.
- Improve clarity and maintainability of the contract through standardized Natspec documentation.

## Impact
- No breaking changes to existing contract behavior.
- New mappings and arrays add storage but are lightweight and gas-efficient.
- Unlocks new opportunities for frontend dashboards, analytics tools, and liquidity tracking features.

## Checklist
- [x] Added `userLiquidity` mapping for per-user liquidity tracking.
- [x] Added `pools` array for pool enumeration and analytics.
- [x] Documented new state variables using Natspec.
- [x] Verified storage layout and ensured no breaking changes.
