### PR TITLE
feat(amm): Introduce `getPoolUsingMarketId` public view accessor with Natspec documentation

### DIFF
--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -434,4 +434,8 @@ contract Test_AMMContract is Ownable {
 
         emit TokensSwapped(_marketId, inputToken, outputToken, _amountIn, amountOut);
     }
+
+    //////////////////////////////////////////////////////////////
+    //                      VIEW FUNCTIONS                     //
+    //////////////////////////////////////////////////////////////
 }

--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -438,4 +438,8 @@ contract Test_AMMContract is Ownable {
     //////////////////////////////////////////////////////////////
     //                      VIEW FUNCTIONS                     //
     //////////////////////////////////////////////////////////////
+
+    function getPoolUsingMarketId(bytes32 marketId) external view returns (PoolData memory) {
+        return marketIdToPool[marketId];
+    }
 }

--- a/src/onchain/TestAMMContract.sol
+++ b/src/onchain/TestAMMContract.sol
@@ -439,6 +439,16 @@ contract Test_AMMContract is Ownable {
     //                      VIEW FUNCTIONS                     //
     //////////////////////////////////////////////////////////////
 
+    /**
+     * @notice Retrieves complete pool data for a given market ID
+     * @dev Returns the PoolData struct containing all pool information
+     *
+     * @param marketId Unique identifier for the prediction market
+     *
+     * @return pool Complete PoolData struct with all pool information
+     *
+     * @custom:lookup Primary method for getting pool information by market ID
+     */
     function getPoolUsingMarketId(bytes32 marketId) external view returns (PoolData memory) {
         return marketIdToPool[marketId];
     }


### PR DESCRIPTION
# Description

This PR adds a dedicated **view section** and a new **external read-only helper function** to the `TestAMMContract`, improving on-chain data accessibility for clients, indexers, and off-chain bots.

---

## ✅ Key Additions

### 🧭 View Function Section Header

A clearly defined section separator was added to distinguish **read-only functions** from core logic:

```solidity
//////////////////////////////////////////////////////////////
//                      VIEW FUNCTIONS                     //
//////////////////////////////////////////////////////////////
